### PR TITLE
allows point label plugin to be scoped to series name

### DIFF
--- a/src/scripts/chartist-plugin-pointlabels.js
+++ b/src/scripts/chartist-plugin-pointlabels.js
@@ -22,14 +22,16 @@
     options = Chartist.extend({}, defaultOptions, options);
 
     return function ctPointLabels(chart) {
-      if(chart instanceof Chartist.Line) {
+      if (chart instanceof Chartist.Line) {
         chart.on('draw', function(data) {
-          if(data.type === 'point') {
-            data.group.elem('text', {
-              x: data.x + options.labelOffset.x,
-              y: data.y + options.labelOffset.y,
-              style: 'text-anchor: ' + options.textAnchor
-            }, options.labelClass).text(options.labelInterpolationFnc(data.value.x === undefined ? data.value.y : data.value.x + ', ' + data.value.y));
+          if (data.type === 'point') {
+            if (options.series ? options.series.indexOf(data.series.name) > -1 : true) {
+              data.group.elem('text', {
+                x: data.x + options.labelOffset.x,
+                y: data.y + options.labelOffset.y,
+                style: 'text-anchor: ' + options.textAnchor
+              }, options.labelClass).text(options.labelInterpolationFnc(data.value.x === undefined ? data.value.y : data.value.x + ', ' + data.value.y));
+            }
           }
         });
       }


### PR DESCRIPTION
# screenshot

<img width="775" alt="screen shot 2016-05-24 at 1 12 46 pm" src="https://cloud.githubusercontent.com/assets/1854811/15522873/426c63d8-21b1-11e6-8f3b-b62658da43e8.png">
# usage

``` javascript
new Chartist.Line('#code-chart-' + id, {
        labels: labels,
        series: [{
            name: 'series-runs',
            data: series
        }, {
            name: 'series-avg',
            data: avg_series
        }]
    }, {
        lineSmooth: Chartist.Interpolation.simple({
            divisor: 2
        }),
        fullWidth: true,
        chartPadding: {
            right: 10
        },
        low: 0,
        axisY: {
            offset: 80,
            labelInterpolationFnc: function(value) {
                return value + 'ms'
            },
            scaleMinSpace: 15
        },
        plugins: [
            Chartist.plugins.ctPointLabels({
                textAnchor: 'middle',
                labelInterpolationFnc: function(value) {
                    return value + 'ms'
                },
                series: ['series-runs']
            })
        ],
        series: {
            'series-runs': {
                showArea: true
            }
        }
    });
```
