### PR TITLE
Fixed a constructor.name issue with IE11 and minifiers.

### DIFF
--- a/dist/chartist-plugin-pointlabels.js
+++ b/dist/chartist-plugin-pointlabels.js
@@ -81,9 +81,7 @@
       }
 
       return function ctPointLabels(chart) {
-        switch (chart.constructor.name) {
-          case 'Line':
-          case 'Bar':
+        if (chart instanceof Chartist.Line || chart instanceof Chartist.Bar) {
           chart.on('draw', function(data) {
             var positonCalculator = labelPositionCalculation[data.type] && labelPositionCalculation[data.type][options.align] || labelPositionCalculation[data.type];
             if (positonCalculator) {

--- a/src/scripts/chartist-plugin-pointlabels.js
+++ b/src/scripts/chartist-plugin-pointlabels.js
@@ -65,9 +65,7 @@
     }
 
     return function ctPointLabels(chart) {
-      switch (chart.constructor.name) {
-        case 'Line':
-        case 'Bar':
+      if (chart instanceof Chartist.Line || chart instanceof Chartist.Bar) {
         chart.on('draw', function(data) {
           var positonCalculator = labelPositionCalculation[data.type] && labelPositionCalculation[data.type][options.align] || labelPositionCalculation[data.type];
           if (positonCalculator) {


### PR DESCRIPTION
Using chart.constructor.name spawned unwanted behavior. See issue #17.