### PR TITLE
Fixes #19 - 0 is not undefined anymore in labels

### DIFF
--- a/dist/chartist-plugin-pointlabels.js
+++ b/dist/chartist-plugin-pointlabels.js
@@ -71,7 +71,9 @@
         // if x and y exist concat them otherwise output only the existing value
         var value = data.value.x !== undefined && data.value.y ?
           (data.value.x + ', ' + data.value.y) :
-          data.value.y || data.value.x;
+          (data.value.y !== undefined ?
+            data.value.y :
+            data.value.x)
 
         data.group.elem('text', {
           x: position.x + options.labelOffset.x,


### PR DESCRIPTION
Handle y=0 while x=undefined with care

#### Explanation 
Before we were getting the bug when `y = 0 and x = undefined` which would cause `value` to be `undefined`
Really that should give use a label of `0` and so `value` should be `0` as well

Also tagging @MartinMuzatko since already submitted a fix : )